### PR TITLE
Update phpmixbill.sql

### DIFF
--- a/system/install/phpmixbill.sql
+++ b/system/install/phpmixbill.sql
@@ -89,7 +89,7 @@ INSERT INTO tbl_language (`id`,`name`,`folder`,`author`) VALUES ("2","English","
 
 CREATE TABLE `tbl_logs` (
   `id` int(10) NOT NULL AUTO_INCREMENT,
-  `date` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `date` datetime NOT NULL DEFAULT '1000-01-01 00:00:00',
   `type` varchar(50) NOT NULL,
   `description` text NOT NULL,
   `userid` int(10) NOT NULL,


### PR DESCRIPTION
The DATETIME type is used for values that contain both date and time parts. MySQL retrieves and displays DATETIME values in 'YYYY-MM-DD hh:mm:ss' format. The supported range is '1000-01-01 00:00:00' to '9999-12-31 23:59:59'.