### PR TITLE
6.43 change in login process and API libraries

### DIFF
--- a/system/autoload/PEAR2/Net/RouterOS/Client.php
+++ b/system/autoload/PEAR2/Net/RouterOS/Client.php
@@ -272,18 +272,12 @@ class Client
         $request->send($com);
         $response = new Response($com, false, $timeout);
         $request->setArgument('name', $username);
-        $request->setArgument(
-            'response',
-            '00' . md5(
-                chr(0) . $password
-                . pack('H*', $response->getProperty('ret'))
-            )
-        );
+        $request->setArgument('password', $password);
         $request->send($com);
         $response = new Response($com, false, $timeout);
-        return $response->getType() === Response::TYPE_FINAL
-            && null === $response->getProperty('ret');
-    }
+       return $response->getType() === Response::TYPE_FINAL
+       null === $response->getProperty('ret');
+ }
     
     /**
      * Sets the charset(s) for this connection.


### PR DESCRIPTION
Pre-6.43 login looks like this:

```Code: Select all
/login
 !done
=ret=ebddd18303a54111e2dea05a92ab46b4
/login
=name=admin
=response=001ea726ed53ae38520c8334f82d44c9f2
 !done```

6.43+ process should be like this:

```/login
=name=admin
=password=
 !done```